### PR TITLE
fix: Fix transparent blocks render issue on non-Chrome browsers

### DIFF
--- a/src/world/ChunkMesher.js
+++ b/src/world/ChunkMesher.js
@@ -128,7 +128,8 @@ export default class ChunkMesher {
         );
         t_geometry.setAttribute("normal", new THREE.BufferAttribute(new Float32Array(t_normals), normalNumComponents));
         t_geometry.setAttribute("uv", new THREE.BufferAttribute(new Float32Array(t_uvs), uvNumComponents));
-        t_geometry.setIndex(t_indices);
+        const size = t_positions.length / 3;
+        t_geometry.setIndex(t_indices.filter(v => v < size));
 
         return { geometry, t_geometry };
     }


### PR DESCRIPTION
The transparent block also can't render on Firefox, and I saw this warning from console:
> WebGL warning: drawElementsInstanced: Indexed vertex fetch requires 1872 vertices, but attribs only supply 1024.

Seems `t_geometry.setIndex` using indeies over size of `t_positions`.

Although I already [refactoring](https://github.com/FlySkyPie/MC.js-Alpha) this project with modern web tools, but I think I should share this fix, thanks for open source this awesome project. :)
